### PR TITLE
Ajout de deux fonds de carte

### DIFF
--- a/src/conf/map-tiles.js
+++ b/src/conf/map-tiles.js
@@ -48,6 +48,22 @@ export default [
     attribution: 'IGN-F/Geoportail'
   },
   {
+    id: 'geoportail-parcelles-cadastrales',
+    name: 'Géoportail / Parcelles cadastrales',
+    type: 'tiles',
+    url:
+      'https://wxs.ign.fr/ff8nyjqym1ym7bz3mw6mpehc/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER=CADASTRALPARCELS.PARCELS&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
+    attribution: 'IGN-F/Geoportail'
+  },
+  {
+    id: 'geoportail-photographies-aeriennes',
+    name: 'Géoportail / Photographies aériennes',
+    type: 'tiles',
+    url:
+      'https://wxs.ign.fr/ff8nyjqym1ym7bz3mw6mpehc/geoportail/wmts?&REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
+    attribution: 'IGN-F/Geoportail'
+  },
+  {
     id: 'brgm-geo',
     name: 'BRGM / Cartes géologiques 1/50 000',
     type: 'wms',


### PR DESCRIPTION
Ajout de deux fonds de carte disponibles via les webservices du geoportail :
WMTS-Géoportail - Parcelles cadastrales     CADASTRALPARCELS.PARCELS
WMTS-Géoportail - Photographies aériennes     ORTHOIMAGERY.ORTHOPHOTOS