### PR TITLE
feat(activités): ajoute le lien vers les activités dans le menu

### DIFF
--- a/src/components/menu/menu.vue
+++ b/src/components/menu/menu.vue
@@ -27,6 +27,17 @@
             </li>
             <li>
               <RouterLink
+                v-if="permissionsCheck(['super', 'admin','editeur'])"
+                id="cmn-menu-menu-a-activites"
+                :to="{ name: 'activites' }"
+                class="btn-transparent text-decoration-none bold"
+                active-class="active"
+              >
+                Activités
+              </RouterLink>
+            </li>
+            <li>
+              <RouterLink
                 id="cmn-menu-menu-a-entreprises"
                 :to="{ name: 'entreprises' }"
                 class="btn-transparent text-decoration-none bold"


### PR DESCRIPTION
ajout dans menu.vue du bloc RouterLink pour les activités vers le liens activites.
Le lien est accessible pour les profils super,admin, et editeur.
Le lien est accessible quelque soit l'entité d'appartenance de l'utilisateur (onf, pref, MTES,...)