### PR TITLE
fix(travaux): corrige l'erreur lors de la saisie de la surface

### DIFF
--- a/src/components/titre/travau-etape/edit.vue
+++ b/src/components/titre/travau-etape/edit.vue
@@ -118,7 +118,7 @@
           placeholder="0"
           :class="{ 'mb-s': etape.surface, mb: !etape.surface }"
         />
-        <label v-if="etape.surface" class="h5">
+        <label v-if="etape.surface && etape.incertitudes" class="h5">
           <input v-model="etape.incertitudes.surface" type="checkbox" />donnée
           incertaine
         </label>


### PR DESCRIPTION
dans la console : '_vm.etape.incertitudes is undefined'