### PR TITLE
fix(matomo): corrige la configuration matomo avec vue 3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ if (import.meta.env.PROD) {
     .then(options => {
       if (!options || !options.host || !options.siteId)
         throw new Error('host et/ou siteId manquant(s)')
-      app.use(VueMatomo, {
+      VueMatomo(app, {
         host: options.host,
         siteId: options.siteId,
         router,

--- a/src/stats/index.js
+++ b/src/stats/index.js
@@ -10,7 +10,7 @@ const defaultOptions = {
   heartBeatTimerInterval: 60
 }
 
-const install = (Vue, setupOptions = {}) => {
+const install = (app, setupOptions = {}) => {
   const options = Object.assign({}, defaultOptions, setupOptions)
 
   bootstrap(options)
@@ -24,7 +24,7 @@ const install = (Vue, setupOptions = {}) => {
       matomo.customVariablePageTitre = pageTitre(matomo)
 
       // bind matomo to Vue
-      Vue.prototype.$matomo = matomo
+      app.config.globalProperties.$matomo = matomo
 
       if (options.requireConsent) {
         matomo.requireConsent()


### PR DESCRIPTION
@NeoBahamut Avec Vue 3, on ne peut plus utiliser `app.prototype...` => https://v3.vuejs.org/guide/migration/global-api.html#vue-prototype-replaced-by-config-globalproperties


Je te laisse vérifier si ça corrige tout.