### PR TITLE
fix(étape): repenser l'UX du bouton Enregistrer sur le formulaire

### DIFF
--- a/src/components/etape-edition.vue
+++ b/src/components/etape-edition.vue
@@ -71,56 +71,25 @@
 
     <div v-else class="tablet-blobs mb" ref="save-btn-container">
       <div class="tablet-blob-1-3" />
-      <div class="tablet-blob-2-3 flex flex-center">
-        <HelpTooltip v-if="armHelpVisible" class="mr-m">
-          Vous pouvez à tout moment enregistrer votre demande. Le dépôt du
-          dossier d’ARM et de toutes les pièces peut être réalisé en plusieurs
-          fois. Vous pourrez compléter votre demande en cliquant sur
-          <span class="inline-block"><i class="icon-24 icon-pencil" /></span>.
-          Si vous avez ajouté tous les documents spécifiques à la demande d’ARM
-          et justificatifs d’entreprise, et que vous considérez que votre
-          demande est complète, vous pouvez la déposer à l’étape suivante en
-          cliquant sur « Déposer … ». L’ONF et le PTMG seront ainsi notifiés et
-          pourront instruire votre demande.
-        </HelpTooltip>
-        <button
-          id="cmn-etape-edit-button-enregistrer"
-          ref="save-button"
-          class="btn-flash rnd-xs p-s full-x"
-          :disabled="!isFormComplete"
-          :class="{ disabled: !isFormComplete }"
-          @click="save"
-        >
-          Enregistrer
-        </button>
-      </div>
+      <FormSaveBtn
+        :arm-help-visible="armHelpVisible"
+        :on-save="save"
+        :disabled="!isFormComplete"
+        class="tablet-blob-2-3 flex flex-center"
+        @click="save"
+      />
     </div>
 
-    <div class="tablet-blobs sticky" :class="{ 'active': isButtonSticky }" ref="save-btn-sticky-container">
+    <div ref="save-btn-sticky-container" :class="{ 'is-active': isButtonSticky }" class="tablet-blobs sticky">
       <div class="tablet-blob-1-3" />
-      <div class="tablet-blob-2-3 flex flex-center">
-        <HelpTooltip v-if="armHelpVisible" class="mr-m">
-          Vous pouvez à tout moment enregistrer votre demande. Le dépôt du
-          dossier d’ARM et de toutes les pièces peut être réalisé en plusieurs
-          fois. Vous pourrez compléter votre demande en cliquant sur
-          <span class="inline-block"><i class="icon-24 icon-pencil" /></span>.
-          Si vous avez ajouté tous les documents spécifiques à la demande d’ARM
-          et justificatifs d’entreprise, et que vous considérez que votre
-          demande est complète, vous pouvez la déposer à l’étape suivante en
-          cliquant sur « Déposer … ». L’ONF et le PTMG seront ainsi notifiés et
-          pourront instruire votre demande.
-        </HelpTooltip>
-        <button
-          id="cmn-etape-edit-button-enregistrer"
-          ref="save-button"
-          class="btn-flash rnd-xs p-s full-x"
-          :disabled="!isFormComplete"
-          :class="{ disabled: !isFormComplete }"
-          @click="save"
-        >
-          Enregistrer
-        </button>
-      </div>
+      <FormSaveBtn
+        :arm-help-visible="armHelpVisible"
+        :on-save="save"
+        :disabled="!isFormComplete"
+        class="tablet-blob-2-3 flex flex-center"
+        @click="save"
+      />
+
     </div>
   </div>
 </template>
@@ -131,10 +100,17 @@ import Loader from './_ui/loader.vue'
 import InputDate from './_ui/input-date.vue'
 import Edit from './etape/edit.vue'
 import HelpTooltip from './_ui/help-tooltip.vue'
+import FormSaveBtn from './etape/form-save-btn.vue'
 // import debounce from 'lodash.debounce'
 
 export default {
-  components: { Loader, Edit, InputDate, HelpTooltip },
+  components: {
+    Loader,
+    Edit,
+    InputDate,
+    HelpTooltip,
+    FormSaveBtn,
+  },
 
   data() {
     return {
@@ -362,7 +338,7 @@ export default {
   pointer-events: none;
 }
 
-.active {
+.is-active {
   transition: opacity 0.25s ease-out;
   opacity: 1;
   pointer-events: auto;

--- a/src/components/etape-edition.vue
+++ b/src/components/etape-edition.vue
@@ -72,6 +72,7 @@
     <div v-else class="tablet-blobs mb" ref="save-btn-container">
       <div class="tablet-blob-1-3" />
       <FormSaveBtn
+        ref="save-btn"
         :arm-help-visible="armHelpVisible"
         :on-save="save"
         :disabled="!isFormComplete"
@@ -80,9 +81,10 @@
       />
     </div>
 
-    <div ref="save-btn-sticky-container" :class="{ 'is-active': isButtonSticky }" class="tablet-blobs sticky">
+    <div ref="save-btn-sticky-container" :class="{ 'is-active': isButtonSticky }" class="tablet-blobs is-sticky">
       <div class="tablet-blob-1-3" />
       <FormSaveBtn
+        ref="save-btn-sticky"
         :arm-help-visible="armHelpVisible"
         :on-save="save"
         :disabled="!isFormComplete"
@@ -101,7 +103,7 @@ import InputDate from './_ui/input-date.vue'
 import Edit from './etape/edit.vue'
 import HelpTooltip from './_ui/help-tooltip.vue'
 import FormSaveBtn from './etape/form-save-btn.vue'
-// import debounce from 'lodash.debounce'
+import debounce from 'lodash.debounce'
 
 export default {
   components: {
@@ -215,6 +217,16 @@ export default {
         this.titreTypeTypeId === 'ar' &&
         this.etapeType.id === 'mfr'
       )
+    },
+
+    saveBtn() {
+      return this.isButtonSticky
+        ? this.$refs['save-btn-sticky']
+        : this.$refs['save-btn']
+    },
+
+    handleStickyBtnDebounced() {
+      return debounce(this.handleStickyBtn)
     }
   },
 
@@ -226,14 +238,14 @@ export default {
     await this.init()
 
     document.addEventListener('keyup', this.keyUp)
-    document.addEventListener('scroll', this.handleStickyBtn)
-    document.addEventListener('resize', this.handleStickyBtn)
+    document.addEventListener('scroll', this.handleStickyBtnDebounced)
+    document.addEventListener('resize', this.handleStickyBtnDebounced)
   },
 
   beforeUnmount() {
     document.removeEventListener('keyup', this.keyUp)
-    document.removeEventListener('scroll', this.handleStickyBtn)
-    document.removeEventListener('resize', this.handleStickyBtn)
+    document.removeEventListener('scroll', this.handleStickyBtnDebounced)
+    document.removeEventListener('resize', this.handleStickyBtnDebounced)
   },
 
   unmounted() {
@@ -284,14 +296,16 @@ export default {
           !this.loading &&
           this.isFormComplete
         ) {
-          this.$refs['save-button'].focus()
+          this.saveBtn.focusBtn()
           this.save()
         }
       }
     },
 
-    handleStickyBtn(e) {
+    handleStickyBtn() {
       const sticky = this.$refs['save-btn-container']
+      if (!sticky) return
+
       const bottomBounds = sticky.getBoundingClientRect().y + sticky.getBoundingClientRect().height
       this.isButtonSticky = window.innerHeight < bottomBounds
       this.adaptStickyBtnWidth()
@@ -326,7 +340,7 @@ export default {
 </script>
 
 <style>
-.sticky {
+.is-sticky {
   background: white;
   height: 70px;
   padding-top: 0px;

--- a/src/components/etape-edition.vue
+++ b/src/components/etape-edition.vue
@@ -72,7 +72,7 @@
     <div
       v-else
       ref="save-btn-container"
-      class="tablet-blobs pb-m pt-m bg-bg sticky"
+      class="tablet-blobs pb-m pt-m bg-bg b-0 sticky"
     >
       <div class="tablet-blob-1-3" />
       <FormSaveBtn
@@ -298,15 +298,6 @@ export default {
       const bottomBounds =
         sticky.getBoundingClientRect().y + sticky.getBoundingClientRect().height
       this.isButtonSticky = window.innerHeight < bottomBounds
-      this.adaptStickyBtnWidth()
-    },
-
-    adaptStickyBtnWidth() {
-      if (!this.isButtonSticky) return
-      const originalWidth =
-        this.$refs['save-btn-container']?.getBoundingClientRect().width
-      const sticky = this.$refs['save-btn-sticky-container']
-      sticky.style.width = originalWidth + 'px'
     },
 
     completeUpdate(complete) {
@@ -329,9 +320,3 @@ export default {
   }
 }
 </script>
-
-<style>
-.is-sticky {
-  bottom: 0;
-}
-</style>

--- a/src/components/etape-edition.vue
+++ b/src/components/etape-edition.vue
@@ -69,7 +69,34 @@
       </div>
     </div>
 
-    <div v-else class="tablet-blobs mb">
+    <div v-else class="tablet-blobs mb" ref="save-btn-container">
+      <div class="tablet-blob-1-3" />
+      <div class="tablet-blob-2-3 flex flex-center">
+        <HelpTooltip v-if="armHelpVisible" class="mr-m">
+          Vous pouvez à tout moment enregistrer votre demande. Le dépôt du
+          dossier d’ARM et de toutes les pièces peut être réalisé en plusieurs
+          fois. Vous pourrez compléter votre demande en cliquant sur
+          <span class="inline-block"><i class="icon-24 icon-pencil" /></span>.
+          Si vous avez ajouté tous les documents spécifiques à la demande d’ARM
+          et justificatifs d’entreprise, et que vous considérez que votre
+          demande est complète, vous pouvez la déposer à l’étape suivante en
+          cliquant sur « Déposer … ». L’ONF et le PTMG seront ainsi notifiés et
+          pourront instruire votre demande.
+        </HelpTooltip>
+        <button
+          id="cmn-etape-edit-button-enregistrer"
+          ref="save-button"
+          class="btn-flash rnd-xs p-s full-x"
+          :disabled="!isFormComplete"
+          :class="{ disabled: !isFormComplete }"
+          @click="save"
+        >
+          Enregistrer
+        </button>
+      </div>
+    </div>
+
+    <div class="tablet-blobs sticky" :class="{ 'active': isButtonSticky }" ref="save-btn-sticky-container">
       <div class="tablet-blob-1-3" />
       <div class="tablet-blob-2-3 flex flex-center">
         <HelpTooltip v-if="armHelpVisible" class="mr-m">
@@ -104,6 +131,7 @@ import Loader from './_ui/loader.vue'
 import InputDate from './_ui/input-date.vue'
 import Edit from './etape/edit.vue'
 import HelpTooltip from './_ui/help-tooltip.vue'
+// import debounce from 'lodash.debounce'
 
 export default {
   components: { Loader, Edit, InputDate, HelpTooltip },
@@ -112,6 +140,8 @@ export default {
     return {
       complete: false,
       typeComplete: false,
+      isButtonSticky: false,
+      containerWidth: 0,
       newDate: new Date().toISOString().slice(0, 10),
       events: { saveKeyUp: true }
     }
@@ -220,10 +250,14 @@ export default {
     await this.init()
 
     document.addEventListener('keyup', this.keyUp)
+    document.addEventListener('scroll', this.handleStickyBtn)
+    document.addEventListener('resize', this.handleStickyBtn)
   },
 
   beforeUnmount() {
     document.removeEventListener('keyup', this.keyUp)
+    document.removeEventListener('scroll', this.handleStickyBtn)
+    document.removeEventListener('resize', this.handleStickyBtn)
   },
 
   unmounted() {
@@ -280,6 +314,20 @@ export default {
       }
     },
 
+    handleStickyBtn(e) {
+      const sticky = this.$refs['save-btn-container']
+      const bottomBounds = sticky.getBoundingClientRect().y + sticky.getBoundingClientRect().height
+      this.isButtonSticky = window.innerHeight < bottomBounds
+      this.adaptStickyBtnWidth()
+    },
+
+    adaptStickyBtnWidth() {
+      if (!this.isButtonSticky) return;
+      const originalWidth = this.$refs['save-btn-container']?.getBoundingClientRect().width
+      const sticky = this.$refs['save-btn-sticky-container']
+      sticky.style.width = originalWidth + 'px';
+    },
+
     completeUpdate(complete) {
       this.complete = complete
     },
@@ -300,3 +348,23 @@ export default {
   }
 }
 </script>
+
+<style>
+.sticky {
+  background: white;
+  height: 70px;
+  padding-top: 0px;
+  margin-bottom: 0px;
+  bottom: 0;
+  position: fixed;
+  opacity: 0;
+  will-change: opacity;
+  pointer-events: none;
+}
+
+.active {
+  transition: opacity 0.25s ease-out;
+  opacity: 1;
+  pointer-events: auto;
+}
+</style>

--- a/src/components/etape-edition.vue
+++ b/src/components/etape-edition.vue
@@ -69,26 +69,14 @@
       </div>
     </div>
 
-    <div v-else ref="save-btn-container" class="tablet-blobs mb">
-      <div class="tablet-blob-1-3" />
-      <FormSaveBtn
-        ref="save-btn"
-        :arm-help-visible="armHelpVisible"
-        :on-save="save"
-        :disabled="!isFormComplete"
-        class="tablet-blob-2-3 flex flex-center"
-        @click="save"
-      />
-    </div>
-
     <div
-      ref="save-btn-sticky-container"
-      :class="{ 'is-active': isButtonSticky }"
-      class="tablet-blobs is-sticky"
+      v-else
+      ref="save-btn-container"
+      class="tablet-blobs pb-m pt-m bg-bg sticky"
     >
       <div class="tablet-blob-1-3" />
       <FormSaveBtn
-        ref="save-btn-sticky"
+        ref="save-btn"
         :arm-help-visible="armHelpVisible"
         :on-save="save"
         :disabled="!isFormComplete"
@@ -344,20 +332,6 @@ export default {
 
 <style>
 .is-sticky {
-  background: white;
-  height: 70px;
-  padding-top: 0px;
-  margin-bottom: 0px;
   bottom: 0;
-  position: fixed;
-  opacity: 0;
-  will-change: opacity;
-  pointer-events: none;
-}
-
-.is-active {
-  transition: opacity 0.25s ease-out;
-  opacity: 1;
-  pointer-events: auto;
 }
 </style>

--- a/src/components/etape-edition.vue
+++ b/src/components/etape-edition.vue
@@ -109,7 +109,6 @@ export default {
   data() {
     return {
       complete: false,
-      monitorChanges: false,
       isFormDirty: false,
       typeComplete: false,
       promptMsg: 'Quitter le formulaire sans enregistrer les changements ?',
@@ -240,10 +239,6 @@ export default {
         id: this.etapeId,
         date: this.newDate
       })
-
-      // Surveille les changements *après* l'init sur le store
-      // pour ignorer les changements initiaux
-      this.monitorChanges = true
     },
 
     beforeWindowUnload(e) {
@@ -304,7 +299,7 @@ export default {
     },
 
     editChange() {
-      if (!this.monitorChanges) return
+      if (!this.loaded) return
       this.isFormDirty = true
     },
 

--- a/src/components/etape-edition.vue
+++ b/src/components/etape-edition.vue
@@ -69,7 +69,7 @@
       </div>
     </div>
 
-    <div v-else class="tablet-blobs mb" ref="save-btn-container">
+    <div v-else ref="save-btn-container" class="tablet-blobs mb">
       <div class="tablet-blob-1-3" />
       <FormSaveBtn
         ref="save-btn"
@@ -81,7 +81,11 @@
       />
     </div>
 
-    <div ref="save-btn-sticky-container" :class="{ 'is-active': isButtonSticky }" class="tablet-blobs is-sticky">
+    <div
+      ref="save-btn-sticky-container"
+      :class="{ 'is-active': isButtonSticky }"
+      class="tablet-blobs is-sticky"
+    >
       <div class="tablet-blob-1-3" />
       <FormSaveBtn
         ref="save-btn-sticky"
@@ -91,7 +95,6 @@
         class="tablet-blob-2-3 flex flex-center"
         @click="save"
       />
-
     </div>
   </div>
 </template>
@@ -101,7 +104,6 @@ import { cap, dateFormat } from '@/utils'
 import Loader from './_ui/loader.vue'
 import InputDate from './_ui/input-date.vue'
 import Edit from './etape/edit.vue'
-import HelpTooltip from './_ui/help-tooltip.vue'
 import FormSaveBtn from './etape/form-save-btn.vue'
 import debounce from 'lodash.debounce'
 
@@ -110,8 +112,7 @@ export default {
     Loader,
     Edit,
     InputDate,
-    HelpTooltip,
-    FormSaveBtn,
+    FormSaveBtn
   },
 
   data() {
@@ -306,16 +307,18 @@ export default {
       const sticky = this.$refs['save-btn-container']
       if (!sticky) return
 
-      const bottomBounds = sticky.getBoundingClientRect().y + sticky.getBoundingClientRect().height
+      const bottomBounds =
+        sticky.getBoundingClientRect().y + sticky.getBoundingClientRect().height
       this.isButtonSticky = window.innerHeight < bottomBounds
       this.adaptStickyBtnWidth()
     },
 
     adaptStickyBtnWidth() {
-      if (!this.isButtonSticky) return;
-      const originalWidth = this.$refs['save-btn-container']?.getBoundingClientRect().width
+      if (!this.isButtonSticky) return
+      const originalWidth =
+        this.$refs['save-btn-container']?.getBoundingClientRect().width
       const sticky = this.$refs['save-btn-sticky-container']
-      sticky.style.width = originalWidth + 'px';
+      sticky.style.width = originalWidth + 'px'
     },
 
     completeUpdate(complete) {

--- a/src/components/etape-edition.vue
+++ b/src/components/etape-edition.vue
@@ -94,7 +94,6 @@ import Loader from './_ui/loader.vue'
 import InputDate from './_ui/input-date.vue'
 import Edit from './etape/edit.vue'
 import FormSaveBtn from './etape/form-save-btn.vue'
-import debounce from 'lodash.debounce'
 
 export default {
   components: { Loader, Edit, InputDate, FormSaveBtn },
@@ -113,7 +112,6 @@ export default {
       monitorChanges: false,
       isFormDirty: false,
       typeComplete: false,
-      isButtonSticky: false,
       promptMsg: 'Quitter le formulaire sans enregistrer les changements ?',
       newDate: new Date().toISOString().slice(0, 10),
       events: { saveKeyUp: true }
@@ -212,16 +210,6 @@ export default {
         this.titreTypeTypeId === 'ar' &&
         this.etapeType.id === 'mfr'
       )
-    },
-
-    saveBtn() {
-      return this.isButtonSticky
-        ? this.$refs['save-btn-sticky']
-        : this.$refs['save-btn']
-    },
-
-    handleStickyBtnDebounced() {
-      return debounce(this.handleStickyBtn)
     }
   },
 
@@ -233,15 +221,11 @@ export default {
     await this.init()
 
     document.addEventListener('keyup', this.keyUp)
-    document.addEventListener('scroll', this.handleStickyBtnDebounced)
-    document.addEventListener('resize', this.handleStickyBtnDebounced)
     window.addEventListener('beforeunload', this.beforeWindowUnload)
   },
 
   beforeUnmount() {
     document.removeEventListener('keyup', this.keyUp)
-    document.removeEventListener('scroll', this.handleStickyBtnDebounced)
-    document.removeEventListener('resize', this.handleStickyBtnDebounced)
     window.removeEventListener('beforeunload', this.beforeWindowUnload)
   },
 
@@ -305,19 +289,10 @@ export default {
           !this.loading &&
           this.isFormComplete
         ) {
-          this.saveBtn.focusBtn()
+          this.$refs['save-btn'].focusBtn()
           this.save()
         }
       }
-    },
-
-    handleStickyBtn() {
-      const sticky = this.$refs['save-btn-container']
-      if (!sticky) return
-
-      const bottomBounds =
-        sticky.getBoundingClientRect().y + sticky.getBoundingClientRect().height
-      this.isButtonSticky = window.innerHeight < bottomBounds
     },
 
     completeUpdate(complete) {

--- a/src/components/etape/edit.vue
+++ b/src/components/etape/edit.vue
@@ -142,7 +142,7 @@ export default {
     documentPopupTitle: { type: String, required: true }
   },
 
-  emits: ['complete-update', 'type-complete-update'],
+  emits: ['complete-update', 'type-complete-update', 'change'],
 
   data() {
     return {
@@ -296,7 +296,14 @@ export default {
   },
 
   watch: {
-    complete: 'completeUpdate'
+    complete: 'completeUpdate',
+
+    etape: {
+      handler: function () {
+        this.$emit('change')
+      },
+      deep: true
+    }
   },
 
   created() {
@@ -361,6 +368,8 @@ export default {
       if (this.opened[stepId]) {
         this.scrollToStep(stepId)
       }
+
+      this.$emit('change')
     },
 
     scrollToStep(stepId) {

--- a/src/components/etape/form-save-btn.vue
+++ b/src/components/etape/form-save-btn.vue
@@ -1,0 +1,47 @@
+<template>
+  <div v-bind="$attrs">
+    <HelpTooltip v-if="armHelpVisible" class="mr-m">
+      Vous pouvez à tout moment enregistrer votre demande. Le dépôt du
+      dossier d’ARM et de toutes les pièces peut être réalisé en plusieurs
+      fois. Vous pourrez compléter votre demande en cliquant sur
+      <span class="inline-block"><i class="icon-24 icon-pencil" /></span>.
+      Si vous avez ajouté tous les documents spécifiques à la demande d’ARM
+      et justificatifs d’entreprise, et que vous considérez que votre
+      demande est complète, vous pouvez la déposer à l’étape suivante en
+      cliquant sur « Déposer … ». L’ONF et le PTMG seront ainsi notifiés et
+      pourront instruire votre demande.
+    </HelpTooltip>
+    <button
+      id="cmn-etape-edit-button-enregistrer"
+      ref="save-button"
+      class="btn-flash rnd-xs p-s full-x"
+      :disabled="$attrs.disabled"
+      :class="{ disabled: $attrs.disabled }"
+      @click="$emit('click')"
+    >
+      Enregistrer
+    </button>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue"
+import HelpTooltip from '../_ui/help-tooltip.vue'
+
+export default defineComponent({
+  components: { HelpTooltip },
+
+  props: {
+    armHelpVisible: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  methods: {
+    focusBtn() {
+      this.$refs['save-btn']?.focus()
+    }
+  }
+})
+</script>

--- a/src/components/etape/form-save-btn.vue
+++ b/src/components/etape/form-save-btn.vue
@@ -13,7 +13,6 @@
     </HelpTooltip>
     <button
       id="cmn-etape-edit-button-enregistrer"
-      ref="save-button"
       class="btn-flash rnd-xs p-s full-x"
       :disabled="$attrs.disabled"
       :class="{ disabled: $attrs.disabled }"

--- a/src/components/etape/form-save-btn.vue
+++ b/src/components/etape/form-save-btn.vue
@@ -1,15 +1,15 @@
 <template>
   <div v-bind="$attrs">
     <HelpTooltip v-if="armHelpVisible" class="mr-m">
-      Vous pouvez à tout moment enregistrer votre demande. Le dépôt du
-      dossier d’ARM et de toutes les pièces peut être réalisé en plusieurs
-      fois. Vous pourrez compléter votre demande en cliquant sur
-      <span class="inline-block"><i class="icon-24 icon-pencil" /></span>.
-      Si vous avez ajouté tous les documents spécifiques à la demande d’ARM
-      et justificatifs d’entreprise, et que vous considérez que votre
-      demande est complète, vous pouvez la déposer à l’étape suivante en
-      cliquant sur « Déposer … ». L’ONF et le PTMG seront ainsi notifiés et
-      pourront instruire votre demande.
+      Vous pouvez à tout moment enregistrer votre demande. Le dépôt du dossier
+      d’ARM et de toutes les pièces peut être réalisé en plusieurs fois. Vous
+      pourrez compléter votre demande en cliquant sur
+      <span class="inline-block"><i class="icon-24 icon-pencil" /></span>. Si
+      vous avez ajouté tous les documents spécifiques à la demande d’ARM et
+      justificatifs d’entreprise, et que vous considérez que votre demande est
+      complète, vous pouvez la déposer à l’étape suivante en cliquant sur «
+      Déposer … ». L’ONF et le PTMG seront ainsi notifiés et pourront instruire
+      votre demande.
     </HelpTooltip>
     <button
       id="cmn-etape-edit-button-enregistrer"
@@ -24,7 +24,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue"
+import { defineComponent } from 'vue'
 import HelpTooltip from '../_ui/help-tooltip.vue'
 
 export default defineComponent({
@@ -36,6 +36,8 @@ export default defineComponent({
       default: false
     }
   },
+
+  emits: ['click'],
 
   methods: {
     focusBtn() {

--- a/src/styles/system/utils.css
+++ b/src/styles/system/utils.css
@@ -211,7 +211,3 @@ http://cssmojo.com/the-very-latest-clearfix-reloaded/
 .z--100 {
   z-index: -100;
 }
-
-.b-0 {
-  bottom: 0;
-}

--- a/src/styles/system/utils.css
+++ b/src/styles/system/utils.css
@@ -122,6 +122,10 @@ http://cssmojo.com/the-very-latest-clearfix-reloaded/
   position: absolute;
 }
 
+.sticky {
+  position: sticky;
+}
+
 .center {
   left: 50%;
   transform: translate(-50%, 0);
@@ -202,4 +206,8 @@ http://cssmojo.com/the-very-latest-clearfix-reloaded/
 
 .z--100 {
   z-index: -100;
+}
+
+.b-0 {
+  bottom: 0
 }

--- a/src/styles/system/utils.css
+++ b/src/styles/system/utils.css
@@ -200,6 +200,10 @@ http://cssmojo.com/the-very-latest-clearfix-reloaded/
   overflow: hidden;
 }
 
+.b-0 {
+  bottom: 0;
+}
+
 .z-2 {
   z-index: 2;
 }
@@ -209,5 +213,5 @@ http://cssmojo.com/the-very-latest-clearfix-reloaded/
 }
 
 .b-0 {
-  bottom: 0
+  bottom: 0;
 }


### PR DESCRIPTION
Empêche l'utilisateur de quitter la page sans avoir sauvegardé des changements : 
- affichage constant du bouton sur la page peu importe son niveau de déroulement ;
- message-guide automatique sur le navigateur lorsque l'utilisateur tente de quitter la page sans avoir sauvegardé ses changements (modifs dans la première tuile ouverte, ou ouverture des autres tuiles)

https://trello.com/c/1hW0r4G9/1647-fix%C3%A9tape-revoir-le-style-du-bouton-enregistrer