### PR TITLE
fix(etape): assure que la propriété 'incertitude' soit manipulable même si originellement null

### DIFF
--- a/src/store/titre.js
+++ b/src/store/titre.js
@@ -158,6 +158,10 @@ const actions = {
 
 const mutations = {
   set(state, titre) {
+    titre?.demarches?.forEach(demarche => demarche?.etapes?.forEach(etp => {
+      etp.incertitudes = etp.incertitudes || {}
+    }))
+
     state.element = titre
   },
 

--- a/src/store/titre.js
+++ b/src/store/titre.js
@@ -158,9 +158,11 @@ const actions = {
 
 const mutations = {
   set(state, titre) {
-    titre?.demarches?.forEach(demarche => demarche?.etapes?.forEach(etp => {
-      etp.incertitudes = etp.incertitudes || {}
-    }))
+    titre?.demarches?.forEach(demarche =>
+      demarche?.etapes?.forEach(etp => {
+        etp.incertitudes = etp.incertitudes || {}
+      })
+    )
 
     state.element = titre
   },


### PR DESCRIPTION
`incertitudes` pouvant être légalement `null`, on pouvait se retrouver avec des tentatives de manipulations de `null` en passant  `etapes.incertitudes` dans des v-models.

Ce bug soulève la nécessité de construire graduellement du typage d'interface pour des props larges à forte valeur métier comme `etapes` (pour plus tard -> https://trello.com/c/2Ve3Lh0V/1672-featetapes-utiliser-ts-pour-cr%C3%A9er-une-interface-pour-la-prop-etape).