### PR TITLE
fix(map): corrige nullité de '_latLngToNewLayerPoint' et 'this._map'

### DIFF
--- a/src/components/_map/leaflet.js
+++ b/src/components/_map/leaflet.js
@@ -33,6 +33,7 @@ const leafletTileLayerDefault = L.tileLayer(
 const leafletMap = map =>
   L.map(map, {
     // zoomControl: true,
+    zoomAnimation: false,
     doubleClickZoom: false,
     minZoom: 1,
     gestureHandling: true,


### PR DESCRIPTION
Voir la discussion sur le sujet : https://trello.com/c/Ly3YIj8Q/1675-fixcarte-corrige-les-erreurs-sentry-de-carte-latlngtonewlayerpoint-et-thismap-null 

Noter que cette correction est une _tentative_ car impossible de reproduire en local jusqu'à maintenant.