### PR TITLE
feat(csp): améliore le header « Content Sercurity Policy »

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,12 @@ const apiMatomoUrl = process.env.API_MATOMO_URL
 const staticFileMiddleware = express.static(path.join(__dirname, 'dist'), {
   setHeaders: (res, path, stat) => {
     res.set({
-      'Content-Security-Policy': `default-src 'self'; script-src 'self' ${apiMatomoUrl} 'sha256-4RS22DYeB7U14dra4KcQYxmwt5HkOInieXK1NUMBmQI=' blob:; style-src 'self' 'sha256-kwpt3lQZ21rs4cld7/uEm9qI5yAbjYzx+9FGm/XmwNU='; connect-src 'self' ${apiUrl} sentry.io ${apiMatomoUrl}; img-src data: 'self' ${apiMatomoUrl} a.tile.openstreetmap.org b.tile.openstreetmap.org c.tile.openstreetmap.org  a.tile.openstreetmap.fr b.tile.openstreetmap.fr c.tile.openstreetmap.fr geoservices.brgm.fr wxs.ign.fr;`,
+      'Content-Security-Policy': `default-src 'none'; script-src 'self' ${apiMatomoUrl} 'sha256-MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=' blob:; style-src 'self'; connect-src 'self' ${apiUrl} sentry.io ${apiMatomoUrl}; img-src data: 'self' a.tile.openstreetmap.org b.tile.openstreetmap.org c.tile.openstreetmap.org  a.tile.openstreetmap.fr b.tile.openstreetmap.fr c.tile.openstreetmap.fr geoservices.brgm.fr wxs.ign.fr; base-uri 'none'; form-action 'self'; frame-ancestors 'none';`,
       'X-Frame-Options': 'DENY',
       'X-Content-Type-Options': 'nosniff',
       'X-XSS-Protection': '1; mode=block',
-      'Access-Control-Allow-Origin': '*'
+      'Access-Control-Allow-Origin': '*',
+      'Referrer-Policy': 'same-origin'
     })
   }
 })


### PR DESCRIPTION
Notre notation actuelle https://observatory.mozilla.org/analyze/camino.beta.gouv.fr

J’ai mis ces modifs en « dur » sur la preprod pour tester rapidement, voici la nouvelle notation https://observatory.mozilla.org/analyze/preprod.camino.beta.gouv.fr