### PR TITLE
fix: corrige les problèmes de layout sur la modale de téléversement

### DIFF
--- a/src/components/document/sections-edit.vue
+++ b/src/components/document/sections-edit.vue
@@ -47,7 +47,7 @@
       </div>
       <div class="tablet-blob-2-3">
         <div v-if="document.fichier || document.fichierNouveau" class="flex">
-          <p class="mb-0">
+          <p class="mb-0 word-break">
             {{
               (document.fichierNouveau && document.fichierNouveau.name) ||
               `${document.id}.${document.fichierTypeId}`


### PR DESCRIPTION
Spécifiquement sur les noms de fichiers très longs.

https://trello.com/c/gxOzEZic/1716-fixboutons-corrige-le-probl%C3%A8me-de-style-sur-les-boutons-lors-de-lajout-dun-fichier