### PR TITLE
feat(page/admin): complète les informations sur l'envoi des emails

### DIFF
--- a/src/components/administration/activites-types-emails.vue
+++ b/src/components/administration/activites-types-emails.vue
@@ -5,12 +5,21 @@
     <div class="tablet-blob-3-4">
       <div class="h6">
         <ul class="list-prefix">
-          <li>Les <strong>DREAL, DEAL et DGTM</strong> sont notifiées pour tous les dépôts d'activité.</li>
-          <li>Les <strong>autres administrations</strong> (préfecture, DIRM, préfet maritime...) sont notifiées uniquement si la production annuelle est non nulle.</li>
+          <li v-if="isFullyNotifiable">
+            Les <strong>DREAL, DEAL et DGTM</strong> sont notifiées pour tous
+            les dépôts d'activité.
+          </li>
+          <li v-else>
+            Les <strong>administrations</strong> (préfecture, DIRM, préfet
+            maritime...) sont notifiées uniquement si la production annuelle est
+            non nulle.
+          </li>
         </ul>
 
-        <p>Lors d’un dépôt d’une activité d’un type en particulier, quels sont les
-        emails à notifier ?</p>
+        <p>
+          Lors d’un dépôt d’une activité d’un type en particulier, quels sont
+          les emails à notifier ?
+        </p>
       </div>
     </div>
 
@@ -116,6 +125,10 @@ export default defineComponent({
         this.activiteTypeNew.email &&
         emailValidator.validate(this.activiteTypeNew.email)
       )
+    },
+
+    isFullyNotifiable() {
+      return ['dea', 'dre'].includes(this.administration?.type?.id)
     }
   },
 

--- a/src/components/administration/activites-types-emails.vue
+++ b/src/components/administration/activites-types-emails.vue
@@ -4,21 +4,12 @@
 
     <div class="tablet-blob-3-4">
       <div class="h6">
-        <ul class="list-prefix">
-          <li v-if="isFullyNotifiable">
-            Les <strong>DREAL, DEAL et DGTM</strong> sont notifiées pour tous
-            les dépôts d'activité.
-          </li>
-          <li v-else>
-            Les <strong>administrations</strong> (préfecture, DIRM, préfet
-            maritime...) sont notifiées uniquement si la production annuelle est
-            non nulle.
-          </li>
-        </ul>
-
         <p>
-          Lors d’un dépôt d’une activité d’un type en particulier, quels sont
-          les emails à notifier ?
+          Lors d’un dépôt d’une activité d’un type en particulier<span
+            v-if="!isFullyNotifiable"
+          >
+            (si la production annuelle est non nulle)</span
+          >, quels sont les emails à notifier ?
         </p>
       </div>
     </div>

--- a/src/components/administration/activites-types-emails.vue
+++ b/src/components/administration/activites-types-emails.vue
@@ -5,10 +5,9 @@
     <div class="tablet-blob-3-4">
       <div class="h6">
         <p>
-          Lors d’un dépôt d’une activité d’un type en particulier<span
-            v-if="!isFullyNotifiable"
-          >
-            (si la production annuelle est non nulle)</span
+          Lors d’un dépôt d’une activité d’un type en particulier
+          <span v-if="!isFullyNotifiable">
+            <strong>si la production annuelle est non nulle</strong></span
           >, quels sont les emails à notifier ?
         </p>
       </div>

--- a/src/components/administration/activites-types-emails.vue
+++ b/src/components/administration/activites-types-emails.vue
@@ -119,7 +119,7 @@ export default defineComponent({
     },
 
     isFullyNotifiable() {
-      return ['dea', 'dre'].includes(this.administration?.type?.id)
+      return ['dea', 'dre', 'min'].includes(this.administration?.type?.id)
     }
   },
 

--- a/src/components/administration/activites-types-emails.vue
+++ b/src/components/administration/activites-types-emails.vue
@@ -2,11 +2,16 @@
   <div v-if="administration.emailsLecture" class="mb-xxl">
     <h3>Emails à notifier lors du dépôt d’un type d’activité</h3>
 
-    <div class="h6">
-      <p class="mb-s">
-        Lors d’un dépôt d’une activité d’un type en particulier, quels sont les
-        emails à notifier ?
-      </p>
+    <div class="tablet-blob-3-4">
+      <div class="h6">
+        <ul class="list-prefix">
+          <li>Les <strong>DREAL, DEAL et DGTM</strong> sont notifiées pour tous les dépôts d'activité.</li>
+          <li>Les <strong>autres administrations</strong> (préfecture, DIRM, préfet maritime...) sont notifiées uniquement si la production annuelle est non nulle.</li>
+        </ul>
+
+        <p>Lors d’un dépôt d’une activité d’un type en particulier, quels sont les
+        emails à notifier ?</p>
+      </div>
     </div>
 
     <div class="line width-full" />


### PR DESCRIPTION
https://trello.com/c/yMkhbVyh/54-feat-page-administration-ajouter-texte-explicatif-sur-emails-%C3%A0-notifier-lors-du-d%C3%A9p%C3%B4t-dun-type-dactivit%C3%A9

<img width="1322" alt="Capture d’écran 2021-11-24 à 10 39 12" src="https://user-images.githubusercontent.com/543614/143213371-a26f2077-5501-4337-a617-1beff2081d6f.png">
