### PR TITLE
feat(activites): ajoute des info-bulles d'aide sur le parcours de remplissages de rapports d'activités

### DIFF
--- a/src/components/activite-edition.test.ts
+++ b/src/components/activite-edition.test.ts
@@ -1,0 +1,111 @@
+import { mount } from '@vue/test-utils'
+import ActiviteEdition from './activite-edition.vue'
+
+describe('ActiviteEdition', () => {
+  test("affiche une info-bulle d'aide si l'activite est de type 'grp' ou 'gra'", () => {
+    const mockRoute = {
+      params: {
+        id: 1
+      }
+    }
+    const mockRouter = {
+      push: jest.fn()
+    }
+
+    const msg =
+      'Tous les champs doivent être remplis même s’il n’y a pas eu d’extraction. Le cas échéant, indiquer seulement 0, puis enregistrer.'
+
+    const $store = {
+      state: {
+        loading: [],
+        user: {
+          element: {}
+        },
+        titreActiviteEdition: {
+          element: {
+            type: {
+              id: 'grp',
+              nom: '',
+              description: 'desc',
+              documentsTypes: []
+            },
+            documents: [],
+            sections: [],
+            titre: {
+              slug: ''
+            },
+            periode: {
+              nom: ''
+            },
+            annee: ''
+          }
+        },
+        popup: {
+          component: {}
+        }
+      },
+      commit: jest.fn(),
+      dispatch: jest.fn()
+    }
+
+    const document = {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn()
+    }
+
+    let wrapper = mount(ActiviteEdition, {
+      global: {
+        mocks: {
+          $store,
+          $route: mockRoute,
+          $router: mockRouter,
+          document
+        },
+        stubs: {
+          RouterLink: true
+        }
+      }
+    })
+
+    expect(wrapper.vm.$store.state.titreActiviteEdition.element.type.id).toBe(
+      'grp'
+    )
+    expect(wrapper.vm.shouldDisplayHelp).toBe(true)
+    let tooltipContent = wrapper.find('.tooltip-content')
+    expect(tooltipContent.exists()).toBe(true)
+    expect(tooltipContent.text()).toContain(msg)
+
+    const secondStore = { ...$store }
+    secondStore.state.titreActiviteEdition.element.type.id = 'gra'
+    expect(wrapper.vm.$store.state.titreActiviteEdition.element.type.id).toBe(
+      'gra'
+    )
+    expect(wrapper.vm.shouldDisplayHelp).toBe(true)
+    tooltipContent = wrapper.find('.tooltip-content')
+    expect(tooltipContent.exists()).toBe(true)
+    expect(tooltipContent.text()).toContain(msg)
+
+    const thirdStore = { ...$store }
+    thirdStore.state.titreActiviteEdition.element.type.id = ''
+
+    wrapper = mount(ActiviteEdition, {
+      global: {
+        mocks: {
+          $store: thirdStore,
+          $route: mockRoute,
+          $router: mockRouter,
+          document
+        },
+        stubs: {
+          RouterLink: true
+        }
+      }
+    })
+
+    expect(wrapper.vm.$store.state.titreActiviteEdition.element.type.id).toBe(
+      ''
+    )
+    expect(wrapper.vm.shouldDisplayHelp).toBe(false)
+    expect(wrapper.find('.tooltip-content').exists()).toBe(false)
+  })
+})

--- a/src/components/activite-edition.vue
+++ b/src/components/activite-edition.vue
@@ -19,9 +19,17 @@
         {{ activite.annee }}</span
       >
     </h5>
-    <h3 class="mb-s">
-      <span class="cap-first">{{ activite.type.nom }}</span>
-    </h3>
+
+    <div class="flex">
+      <h3 class="mb-s">
+        <span class="cap-first">{{ activite.type.nom }}</span>
+      </h3>
+
+      <HelpTooltip v-if="isGrp" class="ml-m">
+        Tous les champs doivent être remplis même s’il n’y a pas eu
+        d’extraction. Le cas échéant, indiquer seulement 0, puis enregistrer.
+      </HelpTooltip>
+    </div>
 
     <!-- eslint-disable vue/no-v-html -->
     <div
@@ -71,11 +79,12 @@
 <script>
 import { dateFormat } from '@/utils'
 import Loader from './_ui/loader.vue'
+import HelpTooltip from './_ui/help-tooltip.vue'
 import SectionsEdit from './activite/sections-edit.vue'
 import DocumentsEdit from './document/multi-edit.vue'
 
 export default {
-  components: { Loader, SectionsEdit, DocumentsEdit },
+  components: { Loader, SectionsEdit, DocumentsEdit, HelpTooltip },
 
   data() {
     return {
@@ -98,6 +107,10 @@ export default {
 
     activite() {
       return this.$store.state.titreActiviteEdition.element
+    },
+
+    isGrp() {
+      return this.activite.type.id === 'grp'
     },
 
     loading() {

--- a/src/components/activite-edition.vue
+++ b/src/components/activite-edition.vue
@@ -25,7 +25,7 @@
         <span class="cap-first">{{ activite.type.nom }}</span>
       </h3>
 
-      <HelpTooltip v-if="isGrp" class="ml-m">
+      <HelpTooltip v-if="shouldDisplayHelp" class="ml-m">
         Tous les champs doivent être remplis même s’il n’y a pas eu
         d’extraction. Le cas échéant, indiquer seulement 0, puis enregistrer.
       </HelpTooltip>
@@ -109,8 +109,8 @@ export default {
       return this.$store.state.titreActiviteEdition.element
     },
 
-    isGrp() {
-      return this.activite.type.id === 'grp'
+    shouldDisplayHelp() {
+      return ['grp', 'gra'].includes(this.activite.type.id)
     },
 
     loading() {

--- a/src/components/activite.vue
+++ b/src/components/activite.vue
@@ -14,8 +14,15 @@
     <Preview
       :key="activite.id"
       :activite="activite"
-      :route="{ name: 'titreActivite', id: activite.slug }"
+      :route="route"
+      :opened-activite="openedActivite"
+      :opened-titre-activite="openedTitreActivite"
       class="mb"
+      @close:titre="titreClose"
+      @close:activite="titreActiviteClose"
+      @toggle:titre="toggleTitre"
+      @toggle:activite="toggleTitreActivite"
+      @popup="popupOpen"
     />
   </div>
 </template>
@@ -23,6 +30,7 @@
 <script>
 import Loader from './_ui/loader.vue'
 import Preview from './activite/preview.vue'
+import RemovePopup from './activite/remove-popup.vue'
 
 export default {
   components: { Loader, Preview },
@@ -38,6 +46,18 @@ export default {
 
     loaded() {
       return !!this.activite
+    },
+
+    openedActivite() {
+      return this.$store.state.titre.opened.activites[this.activite.id]
+    },
+
+    openedTitreActivite() {
+      return this.$store.state.titreActivite.opened
+    },
+
+    route() {
+      return { name: 'titreActivite', id: this.activite.slug }
     }
   },
 
@@ -62,6 +82,41 @@ export default {
   methods: {
     async get() {
       await this.$store.dispatch('titreActivite/get', this.$route.params.id)
+    },
+
+    titreClose() {
+      this.$store.commit('titre/close', {
+        section: 'activites',
+        id: this.activite.id
+      })
+    },
+
+    titreActiviteClose() {
+      this.$store.commit('titreActivite/close')
+    },
+
+    toggleTitre() {
+      this.$store.commit('titre/toggle', {
+        section: 'activites',
+        id: this.activite.id
+      })
+    },
+
+    toggleTitreActivite() {
+      this.$store.commit('titreActivite/toggle')
+    },
+
+    popupOpen() {
+      this.$store.commit('popupOpen', {
+        component: RemovePopup,
+        props: {
+          activiteId: this.activite.id,
+          typeNom: this.activite.type.nom,
+          annee: this.activite.annee,
+          periodeNom: this.activite.periode.nom,
+          route: this.route
+        }
+      })
     }
   }
 }

--- a/src/components/activite/preview.test.ts
+++ b/src/components/activite/preview.test.ts
@@ -1,0 +1,130 @@
+import { mount } from '@vue/test-utils'
+import Preview from './preview.vue'
+
+describe('Activite > Preview', () => {
+  const activite = {
+    date: '2018-01-01',
+    dateSaisie: '2018-01-01',
+    periode: {
+      nom: 'periode'
+    },
+    annee: '2021',
+    type: {
+      id: 'gra'
+    },
+    statut: {
+      id: 'enc',
+      nom: 'en construction',
+      couleur: 'warning'
+    },
+    deposable: true,
+    sections: [{ id: 'id', elements: [] }]
+  }
+
+  test("si l'activite est en construction et déposable, de type 'grp' ou 'gra', affiche une info-bulle d'aide", () => {
+    // En construction, GRA, deposable : OK
+    let wrapper = mount(Preview, {
+      props: {
+        activite,
+        route: {
+          name: 'name'
+        },
+        openedActivite: false,
+        openedTitreActivite: false
+      }
+    })
+
+    expect(wrapper.props('activite').statut.id).toBe('enc')
+    expect(wrapper.props('activite').type.id).toBe('gra')
+    expect(wrapper.props('activite').deposable).toBe(true)
+    let tooltip = wrapper.find('.tooltip-content')
+    expect(tooltip.exists()).toBe(true)
+    expect(tooltip.text()).toContain(
+      'Si votre déclaration est complète, cliquez sur déposer. Cliquez sur le crayon pour modifier.'
+    )
+
+    // En construction, GRP, deposable : OK
+    wrapper = mount(Preview, {
+      props: {
+        activite: { ...activite, type: { id: 'grp' } },
+        route: {
+          name: 'name'
+        },
+        openedActivite: false,
+        openedTitreActivite: false
+      }
+    })
+    expect(wrapper.props('activite').statut.id).toBe('enc')
+    expect(wrapper.props('activite').type.id).toBe('grp')
+    expect(wrapper.props('activite').deposable).toBe(true)
+    tooltip = wrapper.find('.tooltip-content')
+    expect(tooltip.exists()).toBe(true)
+    expect(tooltip.text()).toContain(
+      'Si votre déclaration est complète, cliquez sur déposer. Cliquez sur le crayon pour modifier.'
+    )
+
+    // Autre statut, GRA, deposable : KO
+    wrapper = mount(Preview, {
+      props: {
+        activite: { ...activite, statut: { id: 'foo' } },
+        route: {
+          name: 'name'
+        },
+        openedActivite: false,
+        openedTitreActivite: false
+      }
+    })
+    expect(wrapper.props('activite').statut.id).not.toBe('enc')
+    expect(wrapper.props('activite').type.id).toBe('gra')
+    expect(wrapper.props('activite').deposable).toBe(true)
+    expect(wrapper.find('.tooltip-content').exists()).toBe(false)
+
+    // En construction, GRA, non déposable (déposé) : KO
+    wrapper = mount(Preview, {
+      props: {
+        activite: { ...activite, deposable: null },
+        route: {
+          name: 'name'
+        },
+        openedActivite: false,
+        openedTitreActivite: false
+      }
+    })
+    expect(wrapper.props('activite').statut.id).toBe('enc')
+    expect(wrapper.props('activite').type.id).toBe('gra')
+    expect(wrapper.props('activite').deposable).toBeNull()
+    expect(wrapper.find('.tooltip-content').exists()).toBe(false)
+
+    // En construction, GRA, non déposable (incomplet) : KO
+    wrapper = mount(Preview, {
+      props: {
+        activite: { ...activite, deposable: false },
+        route: {
+          name: 'name'
+        },
+        openedActivite: false,
+        openedTitreActivite: false
+      }
+    })
+    expect(wrapper.props('activite').statut.id).toBe('enc')
+    expect(wrapper.props('activite').type.id).toBe('gra')
+    expect(wrapper.props('activite').deposable).toBe(false)
+    expect(wrapper.find('.tooltip-content').exists()).toBe(false)
+
+    // En construction, autre type, déposable : KO
+    wrapper = mount(Preview, {
+      props: {
+        activite: { ...activite, type: { id: 'XXX' } },
+        route: {
+          name: 'name'
+        },
+        openedActivite: false,
+        openedTitreActivite: false
+      }
+    })
+    expect(wrapper.props('activite').statut.id).toBe('enc')
+    expect(wrapper.props('activite').type.id).toBe('XXX')
+    expect(wrapper.props('activite').deposable).toBe(true)
+    expect(wrapper.find('.tooltip-content').exists()).toBe(false)
+  })
+})

--- a/src/components/activite/preview.vue
+++ b/src/components/activite/preview.vue
@@ -17,9 +17,18 @@
           {{ activite.annee }}</span
         >
       </h5>
-      <h3 class="mb-s">
-        <span class="cap-first">{{ activite.type.nom }}</span>
-      </h3>
+      <div class="flex">
+        <h3 class="mb-s">
+          <span class="cap-first">{{ activite.type.nom }}</span>
+        </h3>
+        <HelpTooltip
+          v-if="isEnConstruction && isActiviteDeposable"
+          class="ml-m"
+        >
+          Si votre déclaration est complète, cliquer sur déposer. Cliquer sur le
+          crayon pour modifier.
+        </HelpTooltip>
+      </div>
       <Statut :color="activite.statut.couleur" :nom="statutNom" class="mb-xs" />
     </template>
     <template #buttons>
@@ -79,6 +88,7 @@
 <script>
 import ActiviteButton from './button.vue'
 import Accordion from '../_ui/accordion.vue'
+import HelpTooltip from '../_ui/help-tooltip.vue'
 import Section from '../_common/section.vue'
 import Statut from '../_common/statut.vue'
 
@@ -92,7 +102,8 @@ export default {
     Accordion,
     Section,
     Statut,
-    Documents
+    Documents,
+    HelpTooltip
   },
 
   props: {
@@ -126,9 +137,17 @@ export default {
     },
 
     statutNom() {
-      return this.activite.statut.id === 'enc' && !this.activite.deposable
+      return this.isEnConstruction && !this.isActiviteDeposable
         ? `${this.activite.statut.nom} (incomplet)`
         : this.activite.statut.nom
+    },
+
+    isEnConstruction() {
+      return this.activite.statut.id === 'enc'
+    },
+
+    isActiviteDeposable() {
+      return this.activite.deposable
     }
   },
 

--- a/src/components/activite/preview.vue
+++ b/src/components/activite/preview.vue
@@ -93,7 +93,6 @@ import Section from '../_common/section.vue'
 import Statut from '../_common/statut.vue'
 
 import Documents from '../documents/list.vue'
-import RemovePopup from './remove-popup.vue'
 import { dateFormat } from '@/utils'
 
 export default {
@@ -108,8 +107,18 @@ export default {
 
   props: {
     activite: { type: Object, required: true },
-    route: { type: Object, required: true }
+    route: { type: Object, required: true },
+    openedActivite: { type: Boolean, required: true },
+    openedTitreActivite: { type: Boolean, required: true }
   },
+
+  emits: [
+    'close:titre',
+    'close:activite',
+    'toggle:titre',
+    'toggle:activite',
+    'popup'
+  ],
 
   computed: {
     documentNew() {
@@ -130,10 +139,10 @@ export default {
 
     opened() {
       if (this.route.name === 'titre') {
-        return this.$store.state.titre.opened.activites[this.activite.id]
+        return this.openedActivite
       }
 
-      return this.$store.state.titreActivite.opened
+      return this.openedTitreActivite
     },
 
     statutNom() {
@@ -153,38 +162,17 @@ export default {
 
   methods: {
     close() {
-      if (this.route.name === 'titre') {
-        this.$store.commit('titre/close', {
-          section: 'activites',
-          id: this.activite.id
-        })
-      } else {
-        this.$store.commit('titreActivite/close')
-      }
+      this.$emit(this.route.name === 'titre' ? 'close:titre' : 'close:activite')
     },
 
     toggle() {
-      if (this.route.name === 'titre') {
-        this.$store.commit('titre/toggle', {
-          section: 'activites',
-          id: this.activite.id
-        })
-      } else {
-        this.$store.commit('titreActivite/toggle')
-      }
+      this.$emit(
+        this.route.name === 'titre' ? 'toggle:titre' : 'toggle:activite'
+      )
     },
 
     activiteRemovePopupOpen() {
-      this.$store.commit('popupOpen', {
-        component: RemovePopup,
-        props: {
-          activiteId: this.activite.id,
-          typeNom: this.activite.type.nom,
-          annee: this.activite.annee,
-          periodeNom: this.activite.periode.nom,
-          route: this.route
-        }
-      })
+      this.$emit('popup')
     },
 
     dateFormat(date) {

--- a/src/components/activite/preview.vue
+++ b/src/components/activite/preview.vue
@@ -21,11 +21,8 @@
         <h3 class="mb-s">
           <span class="cap-first">{{ activite.type.nom }}</span>
         </h3>
-        <HelpTooltip
-          v-if="isEnConstruction && isActiviteDeposable"
-          class="ml-m"
-        >
-          Si votre déclaration est complète, cliquer sur déposer. Cliquer sur le
+        <HelpTooltip v-if="shouldDisplayHelp" class="ml-m">
+          Si votre déclaration est complète, cliquez sur déposer. Cliquez sur le
           crayon pour modifier.
         </HelpTooltip>
       </div>
@@ -156,7 +153,15 @@ export default {
     },
 
     isActiviteDeposable() {
-      return this.activite.deposable
+      return this.activite.deposable === true
+    },
+
+    shouldDisplayHelp() {
+      return (
+        this.isEnConstruction &&
+        this.isActiviteDeposable &&
+        ['grp', 'gra'].includes(this.activite.type.id)
+      )
     }
   },
 


### PR DESCRIPTION
**NE PAS SQUASH !**

Le commit [ef919caeef102f29f4bb5de16c0fda8559b5ff61](https://github.com/MTES-MCT/camino-ui/pull/437/commits/ef919caeef102f29f4bb5de16c0fda8559b5ff61) refactor Activite et son enfant Preview, de manière à faire de Preview un composant "dummy" et le rendre testable. Les changements sont simples, mais il nous faut les garder dans un commit séparé pour des raisons évidentes.