### PR TITLE
fix(activites): retire l'attribut 'primaire' des boutons d'éditions sur la liste

### DIFF
--- a/src/components/activite/button.vue
+++ b/src/components/activite/button.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     class="cmn-activite-btn-remplir btn small flex py-s px-m rnd-0"
-    :class="{ 'btn-primary': activite.statut.id !== 'enc' }"
+    :class="{ 'btn-primary': activite.statut.id !== 'enc' && buttonText }"
     @click="activiteEditPopupOpen"
   >
     <div v-if="buttonText" class="my-xxs">


### PR DESCRIPTION
https://trello.com/c/Gs8gEQfv/69-fixactivit%C3%A9s-enlever-des-boutons-primaires

<img width="1174" alt="Capture d’écran 2021-12-06 à 17 31 32" src="https://user-images.githubusercontent.com/543614/144884500-ebda396a-39eb-4b69-93c8-4ec0296552c1.png">
