### PR TITLE
fix(pdf): corrige la CSP compromettant l'affichage du PDF

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const apiMatomoUrl = process.env.API_MATOMO_URL
 const staticFileMiddleware = express.static(path.join(__dirname, 'dist'), {
   setHeaders: (res, path, stat) => {
     res.set({
-      'Content-Security-Policy': `default-src 'none'; script-src 'self' ${apiMatomoUrl}; style-src 'self'; connect-src 'self' ${apiUrl} sentry.io ${apiMatomoUrl}; img-src data: 'self' a.tile.openstreetmap.org b.tile.openstreetmap.org c.tile.openstreetmap.org  a.tile.openstreetmap.fr b.tile.openstreetmap.fr c.tile.openstreetmap.fr geoservices.brgm.fr wxs.ign.fr datacarto.geoguyane.fr; base-uri 'none'; form-action 'self'; frame-ancestors 'none';`,
+      'Content-Security-Policy': `default-src 'none'; script-src 'self' ${apiMatomoUrl}; style-src 'self' 'unsafe-inline'; connect-src 'self' ${apiUrl} sentry.io ${apiMatomoUrl}; img-src data: 'self' a.tile.openstreetmap.org b.tile.openstreetmap.org c.tile.openstreetmap.org  a.tile.openstreetmap.fr b.tile.openstreetmap.fr c.tile.openstreetmap.fr geoservices.brgm.fr wxs.ign.fr datacarto.geoguyane.fr; base-uri 'none'; form-action 'self'; frame-ancestors 'none';`,
       'X-Frame-Options': 'DENY',
       'X-Content-Type-Options': 'nosniff',
       'X-XSS-Protection': '1; mode=block',


### PR DESCRIPTION
Sur les environnements non-locaux, on a une erreur lors de l'affichage des aperçu de PDFs :

```
Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self'". 
Either the 'unsafe-inline' keyword, a hash ('sha256-tbWZ4NP1341cpcrZVDn7B3o9bt/muXgduILAnC0Zbaw='), or a nonce ('nonce-...') is required to enable inline execution. 
Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present.
```

L'ajout d'une propriété aux CSPs _devrait_ régler ce problème. 
Cet ajout ne change pas l'état de nos CSPs sur cet outil de vérification : https://csp-evaluator.withgoogle.com/